### PR TITLE
Updated CssSelector usage to CssSelectorConverter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "symfony/css-selector": "~2.7",
+    "symfony/css-selector": "~2.8",
     "sabberworm/php-css-parser": "7.0.*"
   },
   "require-dev": {

--- a/src/Northys/CSSInliner/CSSInliner.php
+++ b/src/Northys/CSSInliner/CSSInliner.php
@@ -4,7 +4,7 @@ namespace Northys\CSSInliner;
 
 use Northys\CSSInliner\Exceptions;
 use Sabberworm\CSS;
-use Symfony\Component\CssSelector\CssSelector;
+use Symfony\Component\CssSelector\CssSelectorConverter;
 
 
 /**
@@ -79,7 +79,7 @@ class CSSInliner
 		$this->css = $this->getCSS();
 		foreach ($this->css->getAllRuleSets() as $ruleSet) {
 			$selector = $ruleSet->getSelector();
-			foreach ($this->finder->evaluate(CssSelector::toXPath($selector[0])) as $node) {
+			foreach ($this->finder->evaluate((new CssSelectorConverter())->toXPath($selector[0])) as $node) {
 				if ($node->getAttribute('style')) {
 					$node->setAttribute('style', $node->getAttribute('style') . implode(' ', $ruleSet->getRules()));
 				} else {


### PR DESCRIPTION
Updated to use CssSelectorConverter in order to prevent following error: The Symfony\Component\CssSelector\CssSelector class is deprecated since version 2.8 and will be removed in 3.0. Use directly the \Symfony\Component\CssSelector\CssSelectorConverter class instead.
